### PR TITLE
fix: update AWS SDK to resolve critical fast-xml-parser vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "0.1.0",
       "hasInstallScript": true,
       "dependencies": {
-        "@aws-sdk/client-s3": "^3.775.0",
-        "@aws-sdk/s3-request-presigner": "^3.777.0",
+        "@aws-sdk/client-s3": "^3.1079.0",
+        "@aws-sdk/s3-request-presigner": "^3.1079.0",
         "@node-rs/argon2": "^2.0.2",
         "@oslojs/crypto": "^1.0.1",
         "@oslojs/encoding": "^1.1.0",
@@ -7501,9 +7501,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
     "email": "email dev --dir src/emails"
   },
   "dependencies": {
-    "@aws-sdk/client-s3": "^3.775.0",
-    "@aws-sdk/s3-request-presigner": "^3.777.0",
+    "@aws-sdk/client-s3": "^3.1079.0",
+    "@aws-sdk/s3-request-presigner": "^3.1079.0",
     "@node-rs/argon2": "^2.0.2",
     "@oslojs/crypto": "^1.0.1",
     "@oslojs/encoding": "^1.1.0",


### PR DESCRIPTION
Bumps @aws-sdk/client-s3 and @aws-sdk/s3-request-presigner from 3.775/3.777 to 3.1079, pulling in a patched fast-xml-parser and resolving the critical vulnerability chain (entity injection, DoS, prototype pollution). No API changes needed in our S3 provider code. Reduces vulnerabilities from 10 to 9; remaining issues are in the react-email dependency chain, handled separately.